### PR TITLE
Improve plan prompts and docs

### DIFF
--- a/.github/instructions/rules/isolation_rules/visual-maps/plan-mode-map.md
+++ b/.github/instructions/rules/isolation_rules/visual-maps/plan-mode-map.md
@@ -141,13 +141,19 @@ Before planning can begin, verify the file state:
 
 ```mermaid
 graph TD
-    Start["File State<br>Verification"] --> CheckTasks{"tasks.md<br>initialized?"}
-    
-    CheckTasks -->|"No"| ErrorTasks["ERROR:<br>Return to VAN Mode"]
+    Start["File State<br>Verification"] --> CheckTasks{"tasks.md<br>exists?"}
+
+    CheckTasks -->|"No"| InitTasks["Create tasks.md<br>from description"]
     CheckTasks -->|"Yes"| CheckActive{"activeContext.md<br>exists?"}
+
+    InitTasks --> CheckActive
     
     CheckActive -->|"No"| ErrorActive["ERROR:<br>Return to VAN Mode"]
-    CheckActive -->|"Yes"| ReadyPlan["Ready for<br>Planning"]
+    CheckActive -->|"Yes"| CheckBrief{"projectbrief.md<br>exists?"}
+
+    CheckBrief -->|"No"| InitBrief["Create projectbrief.md<br>from description"]
+    CheckBrief -->|"Yes"| ReadyPlan["Ready for<br>Planning"]
+    InitBrief --> ReadyPlan
 ```
 
 ## 📝 TASKS.MD UPDATE FORMAT

--- a/.github/instructions/rules/isolation_rules/visual-maps/van_mode_split/van-qa-validation.md.old
+++ b/.github/instructions/rules/isolation_rules/visual-maps/van_mode_split/van-qa-validation.md.old
@@ -1,3 +1,6 @@
+---
+description: "Legacy QA validation map"
+---
 # VAN MODE: QA TECHNICAL VALIDATION (Pre-BUILD)
 
 > **TL;DR:** This map details the technical validation process executed *after* CREATIVE mode and *before* BUILD mode, triggered by the `VAN QA` command. It ensures dependencies, configuration, environment, and basic build functionality are sound.

--- a/.github/prompts/creative.prompt.md
+++ b/.github/prompts/creative.prompt.md
@@ -1,3 +1,6 @@
+---
+description: "Design and architecture exploration"
+---
 # MEMORY BANK CREATIVE MODE
 
 Perform detailed design and architecture work for components flagged during the planning phase.

--- a/.github/prompts/implement.prompt.md
+++ b/.github/prompts/implement.prompt.md
@@ -1,3 +1,6 @@
+---
+description: "Implementation of planned changes"
+---
 # MEMORY BANK BUILD MODE
 
 Build the planned changes following the implementation plan and creative phase decisions.

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -1,3 +1,6 @@
+---
+description: "Task planning for Memory Bank projects"
+---
 # MEMORY BANK PLAN MODE
 
 Create a detailed plan for task execution based on the complexity level determined in the initialization mode.
@@ -125,6 +128,19 @@ read_file({
   target_file: ".github/instructions/rules/isolation_rules/Level4/architectural-planning.md",
   should_read_entire_file: true
 })
+```
+
+### Step 4: INITIALIZE CORE DOCUMENTS
+Ensure `tasks.md` and Memory Bank files exist. Populate missing ones with the initialization description.
+
+```
+ensure_file({ target_file: "tasks.md", content_if_missing: "[project description]" })
+ensure_file({ target_file: "memory-bank/projectbrief.md", content_if_missing: "[project description]" })
+ensure_file({ target_file: "memory-bank/productContext.md", content_if_missing: "[project description]" })
+ensure_file({ target_file: "memory-bank/systemPatterns.md", content_if_missing: "[project description]" })
+ensure_file({ target_file: "memory-bank/techContext.md", content_if_missing: "[project description]" })
+ensure_file({ target_file: "memory-bank/activeContext.md", content_if_missing: "[project description]" })
+ensure_file({ target_file: "memory-bank/progress.md", content_if_missing: "[project description]" })
 ```
 
 ## PLANNING APPROACH

--- a/.github/prompts/qa.prompt.md
+++ b/.github/prompts/qa.prompt.md
@@ -1,3 +1,6 @@
+---
+description: "Quality assurance for Memory Bank tasks"
+---
 # MEMORY BANK QA MODE
 
 Perform comprehensive quality assurance checks to verify code integrity and documentation consistency at any phase of development.

--- a/.github/prompts/reflect_archive.prompt.md
+++ b/.github/prompts/reflect_archive.prompt.md
@@ -1,3 +1,6 @@
+---
+description: "Reflection and archiving"
+---
 # MEMORY BANK REFLECT+ARCHIVE MODE
 
 Facilitate reflection on the completed task and, upon explicit command, archive the relevant documentation and update the Memory Bank. This mode combines the final two stages of the development workflow.

--- a/.github/prompts/van.prompt.md
+++ b/.github/prompts/van.prompt.md
@@ -1,3 +1,6 @@
+---
+description: "Initialize Memory Bank and coordinate modes"
+---
 # ADAPTIVE MEMORY-BASED ASSISTANT SYSTEM - ENTRY POINT
 
 > **TL;DR:** Implement a structured Memory Bank system that maintains context across sessions using specialized modes for each development phase.


### PR DESCRIPTION
## Summary
- add YAML descriptions to all prompts
- ensure plan mode initializes tasks.md and key memory bank files
- document tasks creation in plan process map
- add description to legacy QA validation map
- restore initialization template blocks in file verification docs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844be7a9c48832f93ed0e6db98bcd26