### PR TITLE
Add C1+C2 system scheme support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,8 @@ The Memory Bank lives entirely under the `memory-bank/` directory. Never create 
 - `memory-bank/systemPatterns.md` – common patterns and lessons.
 - `memory-bank/techContext.md` – tech stack notes.
 - `memory-bank/scenarios/scenario/<actor>/<touchpoint>/<summary>.md` – user scenarios.
+ - `memory-bank/system-schemes/c1.md` – system scheme description.
+ - `memory-bank/system-schemes/c2.md` – component scheme description.
 - `memory-bank/style-guide.md` – coding style references.
 - `memory-bank/creative/creative-[feature].md` – design explorations.
 - `memory-bank/reflection/reflection-[task].md` – reflection notes.
@@ -35,18 +37,20 @@ Trigger phases using Copilot Chat smart actions:
 - `/reflect` – review the work, capture lessons, and type `ARCHIVE NOW` when ready.
 - `/archive` – finalize documentation after reflection.
 - `/scenario` – generate or update scenario files.
+ - `/c1` – generate or update system scheme descriptions.
+ - `/c2` – generate or update component scheme descriptions.
 
 Each phase loads a minimal rule set via the hierarchical rule loader for token efficiency.
 
 ## 4. Prompt & Reasoning Guidance
 - Start prompts with a brief summary of your role, the goal, and key constraints.
 - Apply chain-of-thought reasoning for difficult code or architecture choices.
-- Load the scenario referenced in `tasks.md` at the start of every phase.
+ - Load the scenario and the referenced system scheme (C1 or C2) from `tasks.md` at the start of every phase.
 - Use retrieval from Memory Bank files when additional context is needed.
 
 ## 5. Verification Checklist
 1. Confirm the `memory-bank/` directory and core files during project setup.
-2. Ensure each task references a scenario file with Actor and Touchpoint.
+ 2. Ensure each task references a scenario file with Actor and Touchpoint and links to the appropriate system scheme (C1 or C2).
 3. Create missing files with platform-aware commands.
 4. Update `tasks.md` and `progress.md` at the end of each workflow phase.
 5. Commit minimal, logically grouped changes with concise messages.

--- a/.github/instructions/rules/isolation_rules/Core/system-scheme-management.md
+++ b/.github/instructions/rules/isolation_rules/Core/system-scheme-management.md
@@ -23,8 +23,10 @@ Record each scheme's file path in `tasks.md` so every workflow phase can load th
 | **Protocols** | HTTP, gRPC, messaging, etc. |
 | **Internal Capabilities** | Optional list of key services or contexts |
 | **Data Stores** | Databases or persistence layers |
-| **Diagram** | Optional mermaid diagram link |
+| **Diagram** | Mermaid diagram code describing the scheme |
 | **Notes** | Additional context |
+
+Schemes must be defined using Mermaid so the diagram code can be stored directly in the repository and versioned like other documents.
 
 C2 schemes expand **Internal Capabilities** into explicit components and list the protocols between them.
 

--- a/.github/instructions/rules/isolation_rules/Core/system-scheme-management.md
+++ b/.github/instructions/rules/isolation_rules/Core/system-scheme-management.md
@@ -1,0 +1,50 @@
+---
+description: "Guidelines for managing system schemes in the Memory Bank"
+globs: "system-scheme-management.md"
+alwaysApply: false
+---
+# MEMORY BANK SYSTEM SCHEME MANAGEMENT
+
+## Overview
+System schemes describe the architecture of the product at two detail levels:
+
+* **C1** – the product is a black box. The scheme lists external systems and the protocols used to communicate with them.
+* **C2** – expands the black box into its internal service components, showing protocols between them and connections to the same external black boxes.
+
+Both scheme levels help coordinate planning and design.
+
+## \ud83d\udcc1 System Scheme Template
+| Field | Description |
+|-------|-------------|
+| **Product/Context Name** | Name of the system or capability |
+| **Purpose** | What this system does |
+| **External Systems** | Other black boxes that interact with it |
+| **Protocols** | HTTP, gRPC, messaging, etc. |
+| **Internal Capabilities** | Optional list of key services or contexts |
+| **Data Stores** | Databases or persistence layers |
+| **Diagram** | Optional mermaid diagram link |
+| **Notes** | Additional context |
+
+C2 schemes expand **Internal Capabilities** into explicit components and list the protocols between them.
+
+## \ud83d\uddd3\ufe0f Scheme Lifecycle
+```mermaid
+graph TD
+    Draft["Draft Scheme"] --> Review["Peer Review"]
+    Review --> Approve{"Approved?"}
+    Approve -->|"Yes"| Use["Use in Development"]
+    Approve -->|"No"| Revise["Revise Scheme"]
+    Use --> UpdateMB["Update Memory Bank"]
+    Revise --> Draft
+```
+
+## \ud83d\uddc2 Storage Conventions
+Store the C1 scheme under `memory-bank/system-schemes/c1.md`.
+Store the C2 scheme under `memory-bank/system-schemes/c2.md`.
+Update `memory-bank/system-schemes/index.md` on every addition.
+
+## \ud83d\udca1 Checklist
+* [ ] Scheme captures purpose and interfaces
+* [ ] Diagram included if useful
+* [ ] Peer review finished
+* [ ] Linked from relevant tasks

--- a/.github/instructions/rules/isolation_rules/Core/system-scheme-management.md
+++ b/.github/instructions/rules/isolation_rules/Core/system-scheme-management.md
@@ -12,6 +12,7 @@ System schemes describe the architecture of the product at two detail levels:
 * **C2** – expands the black box into its internal service components, showing protocols between them and connections to the same external black boxes.
 
 Both scheme levels help coordinate planning and design.
+Record each scheme's file path in `tasks.md` so every workflow phase can load the appropriate diagram.
 
 ## \ud83d\udcc1 System Scheme Template
 | Field | Description |

--- a/.github/instructions/rules/isolation_rules/Level2/workflow-level2.md
+++ b/.github/instructions/rules/isolation_rules/Level2/workflow-level2.md
@@ -274,6 +274,16 @@ Ensure every phase references the user scenario:
 5. Reflection compares results to scenario expectations
 6. Archiving updates scenario status
 
+## \ud83d\udd17 SYSTEM SCHEME C1/C2 INTEGRATION
+
+Maintain system schemes for architectural context:
+
+1. Scheme paths (C1 and C2) recorded during initialization
+2. Planning references the appropriate scheme for design alignment
+3. Creative and Implement phases load scheme details
+4. QA verifies interfaces and dependencies
+5. Reflection logs any scheme updates
+
 ## 🔄 INTEGRATION WITH MEMORY BANK
 
 ```mermaid

--- a/.github/instructions/rules/isolation_rules/Level2/workflow-level2.md
+++ b/.github/instructions/rules/isolation_rules/Level2/workflow-level2.md
@@ -292,8 +292,9 @@ graph TD
     Workflow --> AC["Update<br>activeContext.md"]
     Workflow --> TM["Maintain<br>tasks.md"]
     Workflow --> PM["Update<br>progress.md"]
-    
-    PB & AC & TM & PM --> MB["Memory Bank<br>Integration"]
+    Workflow --> SC["Update<br>C1/C2 Scheme"]
+
+    PB & AC & TM & PM & SC --> MB["Memory Bank<br>Integration"]
     MB --> NextTask["Transition to<br>Next Task"]
 ```
 

--- a/.github/instructions/rules/isolation_rules/visual-maps/creative-mode-map.md
+++ b/.github/instructions/rules/isolation_rules/visual-maps/creative-mode-map.md
@@ -13,9 +13,10 @@ alwaysApply: false
 ```mermaid
 graph TD
     Start["START CREATIVE MODE"] --> ReadTasks["Read tasks.md<br>For Creative Requirements"]
-    
+    ReadTasks --> LoadScheme["Load C1/C2 Scheme"]
+
     %% Initial Assessment
-    ReadTasks --> VerifyPlan{"Plan Complete<br>& Creative Phases<br>Identified?"}
+    LoadScheme --> VerifyPlan{"Plan Complete<br>& Creative Phases<br>Identified?"}
     VerifyPlan -->|"No"| ReturnPlan["Return to<br>PLAN Mode"]
     VerifyPlan -->|"Yes"| IdentifyPhases["Identify Creative<br>Phases Required"]
     

--- a/.github/instructions/rules/isolation_rules/visual-maps/implement-mode-map.md
+++ b/.github/instructions/rules/isolation_rules/visual-maps/implement-mode-map.md
@@ -13,9 +13,10 @@ alwaysApply: false
 ```mermaid
 graph TD
     Start["START BUILD MODE"] --> ReadDocs["Read Reference Documents<br>Core/command-execution.md"]
-    
+    ReadDocs --> LoadScheme["Load C1/C2 Scheme"]
+
     %% Initialization
-    ReadDocs --> CheckLevel{"Determine<br>Complexity Level<br>from tasks.md"}
+    LoadScheme --> CheckLevel{"Determine<br>Complexity Level<br>from tasks.md"}
     
     %% Level 1 Implementation
     CheckLevel -->|"Level 1<br>Quick Bug Fix"| L1Process["LEVEL 1 PROCESS<br>Level1/quick-bug-workflow.md"]

--- a/.github/instructions/rules/isolation_rules/visual-maps/plan-mode-map.md
+++ b/.github/instructions/rules/isolation_rules/visual-maps/plan-mode-map.md
@@ -13,9 +13,10 @@ alwaysApply: false
 ```mermaid
 graph TD
     Start["START PLANNING"] --> ReadTasks["Read tasks.md<br>Core/task-tracking.md"]
-    
+    ReadTasks --> LoadScheme["Load C1/C2 Scheme"]
+
     %% Complexity Level Determination
-    ReadTasks --> CheckLevel{"Determine<br>Complexity Level"}
+    LoadScheme --> CheckLevel{"Determine<br>Complexity Level"}
     CheckLevel -->|"Level 2"| Level2["LEVEL 2 PLANNING<br>Level2/enhancement-planning.md"]
     CheckLevel -->|"Level 3"| Level3["LEVEL 3 PLANNING<br>Level3/feature-planning.md"]
     CheckLevel -->|"Level 4"| Level4["LEVEL 4 PLANNING<br>Level4/system-planning.md"]
@@ -129,6 +130,7 @@ graph TD
     Fix --> Document
     
     style Start fill:#4da6ff,stroke:#0066cc,color:white
+    style LoadScheme fill:#80bfff,stroke:#4da6ff,color:black
     style POC fill:#4da6ff,stroke:#0066cc,color:white
     style Success fill:#ff5555,stroke:#dd3333,color:white
     style Fix fill:#ff5555,stroke:#dd3333,color:white

--- a/.github/instructions/rules/isolation_rules/visual-maps/qa-mode-map.md
+++ b/.github/instructions/rules/isolation_rules/visual-maps/qa-mode-map.md
@@ -25,10 +25,11 @@ graph TD
     UniversalChecks --> MemoryBankCheck["1️⃣ MEMORY BANK VERIFICATION<br>Check consistency & updates"]
     MemoryBankCheck --> TaskTrackingCheck["2️⃣ TASK TRACKING VERIFICATION<br>Validate tasks.md as source of truth"]
     TaskTrackingCheck --> ReferenceCheck["3️⃣ REFERENCE VALIDATION<br>Verify cross-references between docs"]
-    
+    ReferenceCheck --> SchemeCheck["4️⃣ SYSTEM SCHEME VALIDATION"]
+
     %% Phase-specific validations feed into comprehensive report
     VANChecks & PLANChecks & CREATIVEChecks & IMPLEMENTChecks --> PhaseSpecificResults["Phase-Specific Results"]
-    ReferenceCheck & PhaseSpecificResults --> ValidationResults{"✅ All Checks<br>Passed?"}
+    SchemeCheck & PhaseSpecificResults --> ValidationResults{"✅ All Checks<br>Passed?"}
     
     %% Results Processing
     ValidationResults -->|"Yes"| SuccessReport["📝 GENERATE SUCCESS REPORT<br>All validations passed"]
@@ -51,6 +52,7 @@ graph TD
     style MemoryBankCheck fill:#10b981,stroke:#059669,color:white
     style TaskTrackingCheck fill:#10b981,stroke:#059669,color:white
     style ReferenceCheck fill:#10b981,stroke:#059669,color:white
+    style SchemeCheck fill:#10b981,stroke:#059669,color:white
     style ValidationResults fill:#f6546a,stroke:#c30052,color:white
     style SuccessReport fill:#10b981,stroke:#059669,color:white
     style FailureReport fill:#f6ad55,stroke:#c27022,color:white

--- a/.github/instructions/rules/isolation_rules/visual-maps/reflect-mode-map.md
+++ b/.github/instructions/rules/isolation_rules/visual-maps/reflect-mode-map.md
@@ -13,9 +13,10 @@ alwaysApply: false
 ```mermaid
 graph TD
     Start["START REFLECT MODE"] --> ReadTasks["Read tasks.md<br>and progress.md"]
-    
+    ReadTasks --> LoadScheme["Load C1/C2 Scheme"]
+
     %% Initial Assessment
-    ReadTasks --> VerifyImplement{"Implementation<br>Complete?"}
+    LoadScheme --> VerifyImplement{"Implementation<br>Complete?"}
     VerifyImplement -->|"No"| ReturnImplement["Return to<br>IMPLEMENT Mode"]
     VerifyImplement -->|"Yes"| AssessLevel{"Determine<br>Complexity Level"}
     
@@ -40,7 +41,8 @@ graph TD
     %% Level 3-4 Reflection (Comprehensive)
     L3Reflect & L4Reflect --> L34Review["Review Implementation<br>& Creative Phases"]
     L34Review --> L34Plan["Compare Against<br>Original Plan"]
-    L34Plan --> L34WWW["Document<br>What Went Well"]
+    L34Plan --> L34CompareScheme["Compare to System Scheme"]
+    L34CompareScheme --> L34WWW["Document<br>What Went Well"]
     L34WWW --> L34Challenges["Document<br>Challenges"]
     L34Challenges --> L34Lessons["Document<br>Lessons Learned"]
     L34Lessons --> L34ImproveProcess["Document Process<br>Improvements"]

--- a/.github/instructions/rules/isolation_rules/visual-maps/van-mode-map.md
+++ b/.github/instructions/rules/isolation_rules/visual-maps/van-mode-map.md
@@ -96,6 +96,9 @@ graph TD
     
     MBExists -->|"Yes"| VerifyMB["Verify Memory Bank<br>Contents"]
     MBExists -->|"No"| CreateMB["Create Memory Bank<br>Structure"]
+
+    VerifyMB --> SchemeCheck["Check System Scheme Paths"]
+    CreateMB --> SchemeInit["Create System Scheme Stubs"]
     
     CheckFiles --> CheckDocs["Check Documentation<br>Files"]
     CheckDocs --> DocsExist{"Docs<br>Exist?"}
@@ -103,7 +106,7 @@ graph TD
     DocsExist -->|"Yes"| VerifyDocs["Verify Documentation<br>Structure"]
     DocsExist -->|"No"| CreateDocs["Create Documentation<br>Structure"]
     
-    VerifyMB & CreateMB --> MBCP["Memory Bank<br>Checkpoint"]
+    SchemeCheck & SchemeInit --> MBCP["Memory Bank<br>Checkpoint"]
     VerifyDocs & CreateDocs --> DocsCP["Documentation<br>Checkpoint"]
     
     MBCP & DocsCP --> FileComplete["File Verification<br>Complete"]
@@ -112,6 +115,8 @@ graph TD
     style FileComplete fill:#10b981,stroke:#059669,color:white
     style MBCP fill:#f6546a,stroke:#c30052,color:white
     style DocsCP fill:#f6546a,stroke:#c30052,color:white
+    style SchemeCheck fill:#10b981,stroke:#059669,color:white
+    style SchemeInit fill:#10b981,stroke:#059669,color:white
 ```
 
 ## 🧩 COMPLEXITY DETERMINATION PROCESS

--- a/.github/prompts/c1.prompt.md
+++ b/.github/prompts/c1.prompt.md
@@ -4,3 +4,20 @@ description: "Generate or update a system scheme (C1)"
 # MEMORY BANK SYSTEM SCHEME C1 PROMPT
 
 Create or update a system-level scheme that treats the product as a black box and shows interactions with external systems. Follow the template from `system-scheme-management.md`. Save it under `memory-bank/system-schemes/c1.md`.
+
+## Process Overview
+
+```mermaid
+graph TD
+    Start["/c1 invoked"] --> VerifyMB["Check memory-bank folder"]
+    VerifyMB --> LoadTasks["Read tasks.md"]
+    LoadTasks --> PathCheck{"Scheme path recorded?"}
+    PathCheck -- "No" --> Stub["Create c1.md stub"]
+    Stub --> RecordPath["Record path in tasks.md"]
+    PathCheck -- "Yes" --> Gather
+    RecordPath --> Gather
+    Gather["Load projectbrief.md, productContext.md, systemPatterns.md, techContext.md, activeContext.md"] --> FillTemplate["Fill C1 template"]
+    FillTemplate --> SaveScheme["Save c1.md & update index"]
+    SaveScheme --> LogProgress["Update progress.md"]
+    LogProgress --> Done["Done"]
+```

--- a/.github/prompts/c1.prompt.md
+++ b/.github/prompts/c1.prompt.md
@@ -1,0 +1,6 @@
+---
+description: "Generate or update a system scheme (C1)"
+---
+# MEMORY BANK SYSTEM SCHEME C1 PROMPT
+
+Create or update a system-level scheme that treats the product as a black box and shows interactions with external systems. Follow the template from `system-scheme-management.md`. Save it under `memory-bank/system-schemes/c1.md`.

--- a/.github/prompts/c2.prompt.md
+++ b/.github/prompts/c2.prompt.md
@@ -10,7 +10,12 @@ Create or update a component-level scheme that details interactions between the 
 ```mermaid
 graph TD
     Start["/c2 invoked"] --> VerifyMB["Check memory-bank folder"]
-    VerifyMB --> LoadC1["Read c1.md for context"]
+    VerifyMB --> LoadTasks["Read tasks.md"]
+    LoadTasks --> PathCheck{"Scheme path recorded?"}
+    PathCheck -- "No" --> Stub["Create c2.md stub"]
+    Stub --> RecordPath["Record path in tasks.md"]
+    PathCheck -- "Yes" --> LoadC1
+    RecordPath --> LoadC1["Read c1.md for context"]
     LoadC1 --> AnalyzeCode["Analyze components & tasks"]
     AnalyzeCode --> FillTemplate["Fill C2 template"]
     FillTemplate --> SaveScheme["Save c2.md & update index"]

--- a/.github/prompts/c2.prompt.md
+++ b/.github/prompts/c2.prompt.md
@@ -1,0 +1,6 @@
+---
+description: "Generate or update a system scheme (C2)"
+---
+# MEMORY BANK SYSTEM SCHEME C2 PROMPT
+
+Create or update a component-level scheme that details interactions between the service components, their protocols, and external systems. Follow the template from `system-scheme-management.md`. Save it under `memory-bank/system-schemes/c2.md`.

--- a/.github/prompts/c2.prompt.md
+++ b/.github/prompts/c2.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "Generate or update a system scheme (C2)"
+description: "Generate or update a component-level scheme (C2)"
 ---
 # MEMORY BANK SYSTEM SCHEME C2 PROMPT
 

--- a/.github/prompts/c2.prompt.md
+++ b/.github/prompts/c2.prompt.md
@@ -4,3 +4,16 @@ description: "Generate or update a component-level scheme (C2)"
 # MEMORY BANK SYSTEM SCHEME C2 PROMPT
 
 Create or update a component-level scheme that details interactions between the service components, their protocols, and external systems. Follow the template from `system-scheme-management.md`. Save it under `memory-bank/system-schemes/c2.md`.
+
+## Process Overview
+
+```mermaid
+graph TD
+    Start["/c2 invoked"] --> VerifyMB["Check memory-bank folder"]
+    VerifyMB --> LoadC1["Read c1.md for context"]
+    LoadC1 --> AnalyzeCode["Analyze components & tasks"]
+    AnalyzeCode --> FillTemplate["Fill C2 template"]
+    FillTemplate --> SaveScheme["Save c2.md & update index"]
+    SaveScheme --> LogProgress["Update progress.md"]
+    LogProgress --> Done["Done"]
+```

--- a/.github/prompts/creative.prompt.md
+++ b/.github/prompts/creative.prompt.md
@@ -78,7 +78,7 @@ graph TD
 
 ## IMPLEMENTATION STEPS
 
-### Step 1: READ TASKS, SCENARIO & MAIN RULE
+### Step 1: READ TASKS, SCENARIO, SERVICE SCHEME & MAIN RULE
 ```
 read_file({
   target_file: "tasks.md",
@@ -87,6 +87,11 @@ read_file({
 
 read_file({
   target_file: "[scenario file path from tasks.md]",
+  should_read_entire_file: true
+})
+
+read_file({
+  target_file: "[system scheme path from tasks.md (C1 or C2)]",
   should_read_entire_file: true
 })
 

--- a/.github/prompts/creative.prompt.md
+++ b/.github/prompts/creative.prompt.md
@@ -78,7 +78,7 @@ graph TD
 
 ## IMPLEMENTATION STEPS
 
-### Step 1: READ TASKS, SCENARIO, SERVICE SCHEME & MAIN RULE
+### Step 1: READ TASKS, SCENARIO, SYSTEM SCHEME & MAIN RULE
 ```
 read_file({
   target_file: "tasks.md",

--- a/.github/prompts/implement.prompt.md
+++ b/.github/prompts/implement.prompt.md
@@ -81,7 +81,7 @@ read_file({
 })
 ```
 
-### Step 2: READ TASKS, SCENARIO & IMPLEMENTATION PLAN
+### Step 2: READ TASKS, SCENARIO, SERVICE SCHEME & IMPLEMENTATION PLAN
 ```
 read_file({
   target_file: "tasks.md",
@@ -90,6 +90,11 @@ read_file({
 
 read_file({
   target_file: "[scenario file path from tasks.md]",
+  should_read_entire_file: true
+})
+
+read_file({
+  target_file: "[system scheme path from tasks.md (C1 or C2)]",
   should_read_entire_file: true
 })
 

--- a/.github/prompts/implement.prompt.md
+++ b/.github/prompts/implement.prompt.md
@@ -81,7 +81,7 @@ read_file({
 })
 ```
 
-### Step 2: READ TASKS, SCENARIO, SERVICE SCHEME & IMPLEMENTATION PLAN
+### Step 2: READ TASKS, SCENARIO, SYSTEM SCHEME & IMPLEMENTATION PLAN
 ```
 read_file({
   target_file: "tasks.md",

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -72,7 +72,7 @@ graph TD
 
 ## IMPLEMENTATION STEPS
 
-### Step 1: READ MAIN RULE, TASKS, SCENARIO & SERVICE SCHEME
+### Step 1: READ MAIN RULE, TASKS, SCENARIO & SYSTEM SCHEME
 ```
 read_file({
   target_file: ".github/instructions/rules/isolation_rules/main.md",

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -72,7 +72,7 @@ graph TD
 
 ## IMPLEMENTATION STEPS
 
-### Step 1: READ MAIN RULE, TASKS & SCENARIO
+### Step 1: READ MAIN RULE, TASKS, SCENARIO & SERVICE SCHEME
 ```
 read_file({
   target_file: ".github/instructions/rules/isolation_rules/main.md",
@@ -86,6 +86,11 @@ read_file({
 
 read_file({
   target_file: "[scenario file path from tasks.md]",
+  should_read_entire_file: true
+})
+
+read_file({
+  target_file: "[system scheme path from tasks.md (C1 or C2)]",
   should_read_entire_file: true
 })
 ```

--- a/.github/prompts/qa.prompt.md
+++ b/.github/prompts/qa.prompt.md
@@ -5,7 +5,7 @@ description: "Quality assurance for Memory Bank tasks"
 
 Perform comprehensive quality assurance checks to verify code integrity and documentation consistency at any phase of development.
 
-Load the scenario referenced in `tasks.md` and ensure every acceptance criterion is validated.
+Load the scenario and the referenced system scheme (C1 or C2) from `tasks.md` and ensure every acceptance criterion is validated.
 
 ```mermaid
 graph TD

--- a/.github/prompts/reflect_archive.prompt.md
+++ b/.github/prompts/reflect_archive.prompt.md
@@ -115,7 +115,7 @@ read_file({
 ## DEFAULT BEHAVIOR: REFLECTION
 When this mode is activated, it defaults to the REFLECTION process. Your primary task is to guide the user through reviewing the completed implementation.  
 Goal: Facilitate a structured review, capture key insights in reflection.md, and update tasks.md to reflect completion of the reflection phase.
-Load the scenario referenced in `tasks.md` and note how the implementation met or diverged from it.
+Load the scenario and the referenced system scheme (C1 or C2) from `tasks.md` and note how the implementation met or diverged from it.
 
 ```mermaid
 graph TD

--- a/.github/prompts/van.prompt.md
+++ b/.github/prompts/van.prompt.md
@@ -167,6 +167,7 @@ graph TD
 
 ## SCENARIO HANDLING
 If `tasks.md` lacks a scenario path, trigger `/scenario` to create a stub and record the location. Always read the referenced scenario file for context.
+If `tasks.md` lacks a system scheme path, trigger `/c1` or `/c2` to create the appropriate description and record the location.
 
 ## MEMORY BANK FILE STRUCTURE
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each phase has an associated prompt file in `.github/prompts` and can be trigger
 `/scenario` – create or update user scenario files.
 `/c1` – create or update a system scheme description (level C1).
 `/c2` – create or update a component scheme description (level C2).
+The scheme file paths are recorded in `tasks.md` so every phase can load the correct C1 or C2 diagram.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Each phase has an associated prompt file in `.github/prompts` and can be trigger
    - `/plan` – produce or update the implementation plan *(use after gathering requirements)*
    - `/scenario` – create or update user scenario files
    - `/c1` – document or update a system scheme at detail level C1
-   - `/c2` – document or update a system scheme at detail level C2
+   - `/c2` – document or update a component-level scheme at detail level C2
    - `/creative` – brainstorm design approaches for complex components *(helpful for high complexity work)*
    - `/implement` – build the planned components *(use iteratively as you code)*
    - `/qa` – run validation checks to ensure quality *(execute after implementation or whenever needed)*
@@ -59,7 +59,7 @@ Each phase has an associated prompt file in `.github/prompts` and can be trigger
 8. `/qa` – validate the implementation and environment
 9. `/reflect` – document successes and lessons
 10. `/archive` – store final documentation and reset context
-10. Optionally create `.vscode/tasks.json` with helpful build and test commands:
+11. Optionally create `.vscode/tasks.json` with helpful build and test commands:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The Memory Bank workflow divides development into several specialized phases:
 
 Each phase has an associated prompt file in `.github/prompts` and can be triggered from Copilot Chat via a smart action (`/van`, `/plan`, `/creative`, `/implement`, `/qa`, `/reflect`, or `/archive`).
 `/scenario` – create or update user scenario files.
+`/c1` – create or update a system scheme description (level C1).
+`/c2` – create or update a component scheme description (level C2).
 
 ## Installation
 
@@ -37,6 +39,8 @@ Each phase has an associated prompt file in `.github/prompts` and can be trigger
    - `/van` – initialize the Memory Bank and analyze existing tasks *(run once when starting a project)*
    - `/plan` – produce or update the implementation plan *(use after gathering requirements)*
    - `/scenario` – create or update user scenario files
+   - `/c1` – document or update a system scheme at detail level C1
+   - `/c2` – document or update a system scheme at detail level C2
    - `/creative` – brainstorm design approaches for complex components *(helpful for high complexity work)*
    - `/implement` – build the planned components *(use iteratively as you code)*
    - `/qa` – run validation checks to ensure quality *(execute after implementation or whenever needed)*
@@ -48,12 +52,14 @@ Each phase has an associated prompt file in `.github/prompts` and can be trigger
 1. `/van` – create the Memory Bank for the project
 2. `/plan` – outline the tasks and milestones
 3. `/scenario` – document or update user scenarios
-4. `/creative` – explore alternative designs if needed
-5. `/implement` – develop the planned features
-6. `/qa` – validate the implementation and environment
-7. `/reflect` – document successes and lessons
-8. `/archive` – store final documentation and reset context
-9. Optionally create `.vscode/tasks.json` with helpful build and test commands:
+4. `/c1` – generate the system scheme
+5. `/c2` – generate the component scheme
+6. `/creative` – explore alternative designs if needed
+7. `/implement` – develop the planned features
+8. `/qa` – validate the implementation and environment
+9. `/reflect` – document successes and lessons
+10. `/archive` – store final documentation and reset context
+10. Optionally create `.vscode/tasks.json` with helpful build and test commands:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- create `/c2` command prompt for component level schemes
- expand system-scheme-management guide to include C2
- document C2 scheme usage in workflow-level2 and main instructions
- mention new command and example workflow in README
- load C1 or C2 scheme path in prompts and initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684587ac7ca8832f9fde4540f12eec40